### PR TITLE
Fix path handling for output files and clean spider

### DIFF
--- a/bible/data/generate_xml.py
+++ b/bible/data/generate_xml.py
@@ -1,8 +1,11 @@
 import json
+import os
 import xmltodict
 
 # Load the JSON data
-with open('spider.bible_id.json') as f:
+base_dir = os.path.dirname(__file__)
+json_path = os.path.join(base_dir, 'spider.bible_id.json')
+with open(json_path) as f:
     data = json.load(f)
 
 # Create a new dictionary to hold the modified data
@@ -32,5 +35,6 @@ for book_name, chapters in data[0].items():
 xml_data = xmltodict.unparse(modified_data, pretty=True)
 
 # Write the XML data to a file
-with open('spider.bible_id.xml', 'w') as f:
+xml_path = os.path.join(base_dir, 'spider.bible_id.xml')
+with open(xml_path, 'w') as f:
     f.write(xml_data)

--- a/bible/pipelines.py
+++ b/bible/pipelines.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 from scrapy import signals
 from scrapy.exporters import JsonItemExporter
 
@@ -16,7 +17,10 @@ class BiblePipeline(object):
         return pipeline
 
     def spider_opened(self, spider):
-        file = open("data/"+"spider.bible_id"+".json", 'w+b')
+        data_dir = os.path.join(os.path.dirname(__file__), 'data')
+        os.makedirs(data_dir, exist_ok=True)
+        file_path = os.path.join(data_dir, 'spider.bible_id.json')
+        file = open(file_path, 'w+b')
         self.files[spider] = file
         self.exporter = JsonItemExporter(file)
         self.exporter.start_exporting()

--- a/bible/spiders/spider.py
+++ b/bible/spiders/spider.py
@@ -12,14 +12,13 @@ class BibleSpider(scrapy.Spider):
 		# change the language version number the three following line
 		# Iu Mien New Roman: 233 ARA: 1608
         self.bible_id = 59
-        self.base_url = "https://events.bible.com/api/bible/chapter/3.1?id=59&reference="
+        self.base_url = f"https://events.bible.com/api/bible/chapter/3.1?id={self.bible_id}&reference="
         self.start_urls = [
-            'https://events.bible.com/api/bible/chapter/3.1?id=59&reference=GEN.1'
+            f"https://events.bible.com/api/bible/chapter/3.1?id={self.bible_id}&reference=GEN.1"
         ]
 
     def parse(self, response):
-        print("XXXXXXXXXXXXXXXXXXX")
-        print(response)
+        # parse chapter content and accumulate verses
         data = json.loads(response.body.decode('utf-8'))
         text = data['content']
 


### PR DESCRIPTION
## Summary
- ensure file paths in pipeline and XML generator are resolved relative to the code location
- parameterize `bible_id` usage in the spider and remove debug prints

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68536f7449388331b6c291a106e2b19e