### PR TITLE
Fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,12 @@ To run the project, follow these steps:
      source activate bible-scraper
      ```
 
-4. **CD to bible folder and Install requirements**:
+4. **Install requirements**:
 
-   - Run the following command in your terminal:
-     ```bash
-     cd bible
-     pip install -r requirements.txt
-     ```
+  - Run the following command in your terminal from the repository root:
+    ```bash
+    pip install -r requirements.txt
+    ```
 
 5. **Next run "scrapy crawl bible"**:
 


### PR DESCRIPTION
## Summary
- update step 4 in `README` to clarify installing requirements from repo root

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6853717f6b7c83319c5577ccc54d4f84