### PR TITLE
Add minimal test for XML generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,19 +54,30 @@ To run the project, follow these steps:
      scrapy crawl bible
      ```
 
-6. **Install xmltodict**:
+6. **Install xmltodict** (already included in `requirements.txt`):
 
-   - Run the following command in your terminal:
+   - If you installed the requirements in step 4, this package is already
+     available. The step below is optional if you want to install it
+     separately.
      ```bash
      pip install xmltodict
      ```
 
 7. **CD to bible/data folder and run the 'generate_xml.py' file**:
-   - Run the following command in your terminal:
-     ```bash
-     cd bible/data
-     python generate_xml.py
-     ```
+    - Run the following command in your terminal:
+      ```bash
+      cd bible/data
+      python generate_xml.py
+      ```
+
+## Running tests
+
+After installing the requirements you can run the unit tests with `pytest` from
+the repository root:
+
+```bash
+pytest
+```
 
 ## Notes
 

--- a/bible/data/generate_xml.py
+++ b/bible/data/generate_xml.py
@@ -1,40 +1,50 @@
+"""Utility to convert scraped bible JSON data into XML."""
+
+from __future__ import annotations
+
 import json
 import os
+from typing import Any, List
+
 import xmltodict
 
-# Load the JSON data
-base_dir = os.path.dirname(__file__)
-json_path = os.path.join(base_dir, 'spider.bible_id.json')
-with open(json_path) as f:
-    data = json.load(f)
 
-# Create a new dictionary to hold the modified data
-modified_data = {"XMLBIBLE": {"@biblename": "TPT", "BIBLEBOOK": []}}
+def generate_xml_from_data(data: List[Any], bible_name: str = "TPT") -> str:
+    """Convert bible data loaded from JSON to an XML string."""
+    modified_data = {"XMLBIBLE": {"@biblename": bible_name, "BIBLEBOOK": []}}
 
-# Iterate over the books in the Bible
-book_index = 1
-for book_name, chapters in data[0].items():
-    print(f"Processing book: {book_name}")
-    book_data = {"@bnumber": book_index, "@bname": book_name, "CHAPTER": []}
+    book_index = 1
+    for book_name, chapters in data[0].items():
+        book_data = {"@bnumber": book_index, "@bname": book_name, "CHAPTER": []}
 
-    # Iterate over the chapters in the book
-    for chapter_number, verses in chapters.items():
-        chapter_data = {"@cnumber": chapter_number, "VERS": []}
+        for chapter_number, verses in chapters.items():
+            chapter_data = {"@cnumber": chapter_number, "VERS": []}
 
-        # Iterate over the verses in the chapter
-        for verse_number, verse_text in verses.items():
-            verse_data = {"@vnumber": verse_number, "#text": verse_text}
-            chapter_data["VERS"].append(verse_data)
+            for verse_number, verse_text in verses.items():
+                verse_data = {"@vnumber": verse_number, "#text": verse_text}
+                chapter_data["VERS"].append(verse_data)
 
-        book_data["CHAPTER"].append(chapter_data)
+            book_data["CHAPTER"].append(chapter_data)
 
-    modified_data["XMLBIBLE"]["BIBLEBOOK"].append(book_data)
-    book_index += 1
+        modified_data["XMLBIBLE"]["BIBLEBOOK"].append(book_data)
+        book_index += 1
 
-# Convert the modified data to XML
-xml_data = xmltodict.unparse(modified_data, pretty=True)
+    return xmltodict.unparse(modified_data, pretty=True)
 
-# Write the XML data to a file
-xml_path = os.path.join(base_dir, 'spider.bible_id.xml')
-with open(xml_path, 'w') as f:
-    f.write(xml_data)
+
+def main() -> None:
+    """Entry point used when running this module as a script."""
+    base_dir = os.path.dirname(__file__)
+    json_path = os.path.join(base_dir, "spider.bible_id.json")
+    with open(json_path) as f:
+        data = json.load(f)
+
+    xml_data = generate_xml_from_data(data, bible_name="TPT")
+
+    xml_path = os.path.join(base_dir, "spider.bible_id.xml")
+    with open(xml_path, "w") as f:
+        f.write(xml_data)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 scrapy
+xmltodict
+pytest

--- a/tests/test_generate_xml.py
+++ b/tests/test_generate_xml.py
@@ -1,0 +1,29 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from bible.data.generate_xml import generate_xml_from_data
+
+
+def test_generate_xml_basic():
+    sample_json = [
+        {
+            "Genesis": {
+                "1": {
+                    "1": "In the beginning",
+                    "2": "The earth was without form"
+                },
+                "2": {
+                    "1": "Thus the heavens and the earth were finished"
+                }
+            }
+        }
+    ]
+
+    xml_output = generate_xml_from_data(sample_json, bible_name="TEST")
+
+    assert "<XMLBIBLE biblename=\"TEST\">" in xml_output
+    assert "<BIBLEBOOK bnumber=\"1\" bname=\"Genesis\">" in xml_output
+    assert "<CHAPTER cnumber=\"1\">" in xml_output
+    assert "<VERS vnumber=\"1\">In the beginning</VERS>" in xml_output


### PR DESCRIPTION
## Summary
- refactor `generate_xml.py` into a callable function
- add test covering XML generation
- document test execution in README
- add `xmltodict` and `pytest` to requirements

## Testing
- `pip install -r requirements.txt` *(fails: Could not install packages)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'xmltodict')*

------
https://chatgpt.com/codex/tasks/task_e_6853716e89548331a4032a48d117c254